### PR TITLE
[STEP 3] ERD & 서비스 구현

### DIFF
--- a/src/main/java/io/hhplus/architecture/ArchitectureApplication.java
+++ b/src/main/java/io/hhplus/architecture/ArchitectureApplication.java
@@ -2,9 +2,7 @@ package io.hhplus.architecture;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class ArchitectureApplication {
 

--- a/src/main/java/io/hhplus/architecture/config/JpaConfig.java
+++ b/src/main/java/io/hhplus/architecture/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package io.hhplus.architecture.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
+++ b/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
@@ -7,6 +7,7 @@ import io.hhplus.architecture.lecture.domain.repository.LectureOptionRepository;
 import io.hhplus.architecture.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class LectureService {
     private final LectureOptionRepository lectureOptionRepository;
     private final LectureApplicantRepository lectureApplicantRepository;
 
+    @Transactional
     public LectureApplicant applyLecture(long lectureOptionId, long userId) {
         // 예외 - 기존에 신청한 경우
         lectureApplicantRepository.findByUserIdAndLectureOptionId(userId, lectureOptionId)
@@ -42,10 +44,12 @@ public class LectureService {
         return lectureApplicantRepository.apply(new LectureApplicant(lectureOption, userId));
     }
 
+    @Transactional(readOnly = true)
     public List<LectureOption> getLectures() {
         return lectureOptionRepository.findAll();
     }
 
+    @Transactional(readOnly = true)
     public List<LectureApplicant> getAppliedLecturesByUser(long userId) {
         return lectureApplicantRepository.findAllByUserId(userId);
     }

--- a/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
+++ b/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
@@ -29,7 +29,7 @@ public class LectureService {
 
         // 예외 - 존재하지 않는 특강 옵션인 경우
         LectureOption lectureOption =
-                lectureOptionRepository.findById(lectureOptionId)
+                lectureOptionRepository.findByIdWithPessimisticLock(lectureOptionId)
                                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 특강입니다."));
 
         // 예외 - 특강 최대 정원만큼 신청된 경우

--- a/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
+++ b/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,9 +29,12 @@ public class LectureService {
                                   });
 
         // 예외 - 존재하지 않는 특강 옵션인 경우
-        LectureOption lectureOption =
-                lectureOptionRepository.findByIdWithPessimisticLock(lectureOptionId)
-                                       .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 특강입니다."));
+        Optional<LectureOption> lo = lectureOptionRepository.findByIdWithPessimisticLock(lectureOptionId);
+        if (lo.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 특강입니다.");
+        }
+
+        LectureOption lectureOption = lo.get();
 
         // 예외 - 특강 최대 정원만큼 신청된 경우
         lectureOption.isFull();

--- a/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
+++ b/src/main/java/io/hhplus/architecture/lecture/application/LectureService.java
@@ -1,4 +1,52 @@
 package io.hhplus.architecture.lecture.application;
 
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import io.hhplus.architecture.lecture.domain.repository.LectureApplicantRepository;
+import io.hhplus.architecture.lecture.domain.repository.LectureOptionRepository;
+import io.hhplus.architecture.lecture.domain.repository.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final LectureOptionRepository lectureOptionRepository;
+    private final LectureApplicantRepository lectureApplicantRepository;
+
+    public LectureApplicant applyLecture(long lectureOptionId, long userId) {
+        // 예외 - 기존에 신청한 경우
+        lectureApplicantRepository.findByUserIdAndLectureOptionId(userId, lectureOptionId)
+                                  .ifPresent(applicant -> {
+                                      throw new IllegalStateException("이미 신청한 특강입니다.");
+                                  });
+
+        // 예외 - 존재하지 않는 특강 옵션인 경우
+        LectureOption lectureOption =
+                lectureOptionRepository.findById(lectureOptionId)
+                                       .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 특강입니다."));
+
+        // 예외 - 특강 최대 정원만큼 신청된 경우
+        lectureOption.isFull();
+
+        // 예외 - 신청할 수 없는 날짜인 경우
+        lectureOption.validateLectureDate();
+
+        lectureOption.increaseAppliedCount(lectureOption.getAppliedCount() + 1);
+        lectureOptionRepository.save(lectureOption);
+
+        return lectureApplicantRepository.apply(new LectureApplicant(lectureOption, userId));
+    }
+
+    public List<LectureOption> getLectures() {
+        return lectureOptionRepository.findAll();
+    }
+
+    public List<LectureApplicant> getAppliedLecturesByUser(long userId) {
+        return lectureApplicantRepository.findAllByUserId(userId);
+    }
 }

--- a/src/main/java/io/hhplus/architecture/lecture/domain/Lecture.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/Lecture.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture {
     @Id
@@ -32,6 +34,11 @@ public class Lecture {
 
     public Lecture(Long id, String title, String speaker) {
         this.id = id;
+        this.title = title;
+        this.speaker = speaker;
+    }
+
+    public Lecture(String title, String speaker) {
         this.title = title;
         this.speaker = speaker;
     }

--- a/src/main/java/io/hhplus/architecture/lecture/domain/Lecture.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/Lecture.java
@@ -1,4 +1,38 @@
 package io.hhplus.architecture.lecture.domain;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String speaker;
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public Lecture(Long id, String title, String speaker) {
+        this.id = id;
+        this.title = title;
+        this.speaker = speaker;
+    }
 }

--- a/src/main/java/io/hhplus/architecture/lecture/domain/LectureApplicant.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/LectureApplicant.java
@@ -1,0 +1,61 @@
+package io.hhplus.architecture.lecture.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LectureApplicant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "lecture_option_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private LectureOption lectureOption;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public LectureApplicant(LectureOption lectureOption, Long userId) {
+        this.lectureOption = lectureOption;
+        this.userId = userId;
+    }
+
+    public LectureApplicant(Long id, LectureOption lectureOption, Long userId) {
+        this.id = id;
+        this.lectureOption = lectureOption;
+        this.userId = userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LectureApplicant that = (LectureApplicant) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/io/hhplus/architecture/lecture/domain/LectureOption.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/LectureOption.java
@@ -1,0 +1,75 @@
+package io.hhplus.architecture.lecture.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LectureOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "lecture_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Lecture lecture;
+
+    @Column(nullable = false)
+    private LocalDate lectureDate;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    @Column(nullable = false)
+    private Long maxCapacity;
+
+    @Column(nullable = false)
+    private Long appliedCount;
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public LectureOption(Long id, Lecture lecture, LocalDate lectureDate, LocalTime startTime, LocalTime endTime, Long maxCapacity, Long appliedCount) {
+        this.id = id;
+        this.lecture = lecture;
+        this.lectureDate = lectureDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.maxCapacity = maxCapacity;
+        this.appliedCount = appliedCount;
+    }
+
+    public void isFull() {
+        if (Objects.equals(appliedCount, maxCapacity)) {
+            throw new IllegalStateException("선착순 마감되었습니다.");
+        }
+    }
+
+    public void validateLectureDate() {
+        if (lectureDate.isBefore(LocalDate.now())) {
+            throw new IllegalStateException("신청할 수 없는 날짜입니다.");
+        }
+    }
+
+    public void increaseAppliedCount(long currentCount) {
+        appliedCount = currentCount;
+    }
+}

--- a/src/main/java/io/hhplus/architecture/lecture/domain/LectureOption.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/LectureOption.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LectureOption {
     @Id
@@ -49,6 +51,15 @@ public class LectureOption {
 
     public LectureOption(Long id, Lecture lecture, LocalDate lectureDate, LocalTime startTime, LocalTime endTime, Long maxCapacity, Long appliedCount) {
         this.id = id;
+        this.lecture = lecture;
+        this.lectureDate = lectureDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.maxCapacity = maxCapacity;
+        this.appliedCount = appliedCount;
+    }
+
+    public LectureOption(Lecture lecture, LocalDate lectureDate, LocalTime startTime, LocalTime endTime, Long maxCapacity, Long appliedCount) {
         this.lecture = lecture;
         this.lectureDate = lectureDate;
         this.startTime = startTime;

--- a/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureApplicantRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureApplicantRepository.java
@@ -1,0 +1,14 @@
+package io.hhplus.architecture.lecture.domain.repository;
+
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LectureApplicantRepository {
+    List<LectureApplicant> findAllByUserId(Long userId);
+
+    LectureApplicant apply(LectureApplicant applicant);
+
+    Optional<LectureApplicant> findByUserIdAndLectureOptionId(Long userId, Long lectureOptionId);
+}

--- a/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
@@ -1,0 +1,14 @@
+package io.hhplus.architecture.lecture.domain.repository;
+
+import io.hhplus.architecture.lecture.domain.LectureOption;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LectureOptionRepository {
+    List<LectureOption> findAll();
+
+    Optional<LectureOption> findById(long id);
+
+    LectureOption save(LectureOption lectureOption);
+}

--- a/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface LectureOptionRepository {
     List<LectureOption> findAll();
 
-    Optional<LectureOption> findById(long id);
+    Optional<LectureOption> findByIdWithPessimisticLock(long id);
 
     LectureOption save(LectureOption lectureOption);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureOptionRepository.java
@@ -10,5 +10,7 @@ public interface LectureOptionRepository {
 
     Optional<LectureOption> findByIdWithPessimisticLock(long id);
 
+    Optional<LectureOption> findById(long id);
+
     LectureOption save(LectureOption lectureOption);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/domain/repository/LectureRepository.java
@@ -1,4 +1,8 @@
 package io.hhplus.architecture.lecture.domain.repository;
 
+import io.hhplus.architecture.lecture.domain.Lecture;
+
 public interface LectureRepository {
+
+    Lecture save(Lecture lecture);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureApplicantJpaRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureApplicantJpaRepository.java
@@ -1,0 +1,14 @@
+package io.hhplus.architecture.lecture.infrastructure;
+
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LectureApplicantJpaRepository extends JpaRepository<LectureApplicant, Long> {
+
+    List<LectureApplicant> findAllByUserId(long userId);
+
+    Optional<LectureApplicant> findByUserIdAndLectureOption_Id(long userId, long lectureOptionId);
+}

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureApplicantRepositoryImpl.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureApplicantRepositoryImpl.java
@@ -1,0 +1,31 @@
+package io.hhplus.architecture.lecture.infrastructure;
+
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+import io.hhplus.architecture.lecture.domain.repository.LectureApplicantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureApplicantRepositoryImpl implements LectureApplicantRepository {
+
+    private final LectureApplicantJpaRepository repository;
+
+    @Override
+    public List<LectureApplicant> findAllByUserId(Long userId) {
+        return repository.findAllByUserId(userId);
+    }
+
+    @Override
+    public LectureApplicant apply(LectureApplicant applicant) {
+        return repository.save(applicant);
+    }
+
+    @Override
+    public Optional<LectureApplicant> findByUserIdAndLectureOptionId(Long userId, Long lectureOptionId) {
+        return repository.findByUserIdAndLectureOption_Id(userId, lectureOptionId);
+    }
+}

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
@@ -4,11 +4,13 @@ import io.hhplus.architecture.lecture.domain.LectureOption;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface LectureOptionJpaRepository extends JpaRepository<LectureOption, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<LectureOption> findById(long id);
+    @Query("SELECT lo FROM LectureOption lo WHERE lo.id = :id")
+    Optional<LectureOption> findByIdWithPessimisticLock(long id);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,5 +13,5 @@ public interface LectureOptionJpaRepository extends JpaRepository<LectureOption,
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT lo FROM LectureOption lo WHERE lo.id = :id")
-    Optional<LectureOption> findByIdWithPessimisticLock(long id);
+    Optional<LectureOption> findByIdWithPessimisticLock(@Param("id") long id);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
@@ -1,0 +1,7 @@
+package io.hhplus.architecture.lecture.infrastructure;
+
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureOptionJpaRepository extends JpaRepository<LectureOption, Long> {
+}

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionJpaRepository.java
@@ -1,7 +1,14 @@
 package io.hhplus.architecture.lecture.infrastructure;
 
 import io.hhplus.architecture.lecture.domain.LectureOption;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface LectureOptionJpaRepository extends JpaRepository<LectureOption, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<LectureOption> findById(long id);
 }

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
@@ -25,7 +25,12 @@ public class LectureOptionRepositoryImpl implements LectureOptionRepository {
     }
 
     @Override
+    public Optional<LectureOption> findById(long id) {
+        return repository.findById(id);
+    }
+
+    @Override
     public LectureOption save(LectureOption lectureOption) {
-        return repository.save(lectureOption);
+        return repository.saveAndFlush(lectureOption);
     }
 }

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
@@ -20,8 +20,8 @@ public class LectureOptionRepositoryImpl implements LectureOptionRepository {
     }
 
     @Override
-    public Optional<LectureOption> findById(long id) {
-        return repository.findById(id);
+    public Optional<LectureOption> findByIdWithPessimisticLock(long id) {
+        return repository.findByIdWithPessimisticLock(id);
     }
 
     @Override

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureOptionRepositoryImpl.java
@@ -1,0 +1,31 @@
+package io.hhplus.architecture.lecture.infrastructure;
+
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import io.hhplus.architecture.lecture.domain.repository.LectureOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureOptionRepositoryImpl implements LectureOptionRepository {
+
+    private final LectureOptionJpaRepository repository;
+
+    @Override
+    public List<LectureOption> findAll() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Optional<LectureOption> findById(long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public LectureOption save(LectureOption lectureOption) {
+        return repository.save(lectureOption);
+    }
+}

--- a/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/architecture/lecture/infrastructure/LectureRepositoryImpl.java
@@ -1,5 +1,6 @@
 package io.hhplus.architecture.lecture.infrastructure;
 
+import io.hhplus.architecture.lecture.domain.Lecture;
 import io.hhplus.architecture.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,9 @@ import org.springframework.stereotype.Repository;
 public class LectureRepositoryImpl implements LectureRepository {
 
     private final LectureJpaRepository repository;
+
+    @Override
+    public Lecture save(Lecture lecture) {
+        return repository.save(lecture);
+    }
 }

--- a/src/main/java/io/hhplus/architecture/lecture/presentation/LectureApplyRequestDto.java
+++ b/src/main/java/io/hhplus/architecture/lecture/presentation/LectureApplyRequestDto.java
@@ -1,0 +1,11 @@
+package io.hhplus.architecture.lecture.presentation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureApplyRequestDto {
+    private long lectureOptionId;
+    private long userId;
+}

--- a/src/main/java/io/hhplus/architecture/lecture/presentation/LectureController.java
+++ b/src/main/java/io/hhplus/architecture/lecture/presentation/LectureController.java
@@ -1,4 +1,32 @@
 package io.hhplus.architecture.lecture.presentation;
 
+import io.hhplus.architecture.lecture.application.LectureService;
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/lectures")
+@RequiredArgsConstructor
 public class LectureController {
+
+    private final LectureService lectureService;
+
+    @PostMapping("apply")
+    public LectureApplicant applyLecture(@RequestBody LectureApplyRequestDto request) {
+        return lectureService.applyLecture(request.getLectureOptionId(), request.getUserId());
+    }
+
+    @GetMapping("")
+    public List<LectureOption> getLectures() {
+        return lectureService.getLectures();
+    }
+
+    @GetMapping("application/{userId}")
+    public List<LectureApplicant> getAppliedLecturesByUser(@PathVariable long userId) {
+        return lectureService.getAppliedLecturesByUser(userId);
+    }
 }

--- a/src/test/java/io/hhplus/architecture/config/TestConfig.java
+++ b/src/test/java/io/hhplus/architecture/config/TestConfig.java
@@ -1,0 +1,12 @@
+package io.hhplus.architecture.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration
+@ComponentScan(excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaConfig.class)
+})
+public class TestConfig {
+}

--- a/src/test/java/io/hhplus/architecture/lecture/LectureIntegrationTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/LectureIntegrationTest.java
@@ -1,0 +1,81 @@
+package io.hhplus.architecture.lecture;
+
+import io.hhplus.architecture.lecture.application.LectureService;
+import io.hhplus.architecture.lecture.domain.Lecture;
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import io.hhplus.architecture.lecture.domain.repository.LectureOptionRepository;
+import io.hhplus.architecture.lecture.domain.repository.LectureRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class LectureIntegrationTest {
+
+    @Autowired
+    private LectureService lectureService;
+
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private LectureOptionRepository lectureOptionRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Test
+    @DisplayName("특강 신청 - 비관적 락 테스트")
+    void lecture_apply_with_pessimistic_lock() throws InterruptedException {
+        //given
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+        LocalDate lectureDate = LocalDate.of(2024, 7, 1);
+        LocalTime startTime = LocalTime.of(13, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+        Long maxCapacity = 3L;
+        Long appliedCount = 0L;
+
+        Lecture lecture = new Lecture(title, speaker);
+        lectureRepository.save(lecture);
+
+        LectureOption lectureOption = new LectureOption(
+                lecture, lectureDate, startTime, endTime, maxCapacity, appliedCount);
+        lectureOptionRepository.save(lectureOption);
+
+        AtomicLong userId = new AtomicLong(1L);
+
+        final int threadCount = 10;
+        final ExecutorService executorService = Executors.newFixedThreadPool(5);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    lectureService.applyLecture(lectureOptionId, userId.getAndIncrement());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        final LectureOption lo = lectureOptionRepository.findById(1L).get();
+        assertThat(lo.getAppliedCount()).isEqualTo(lo.getMaxCapacity());
+    }
+}

--- a/src/test/java/io/hhplus/architecture/lecture/application/LectureServiceTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/application/LectureServiceTest.java
@@ -60,7 +60,7 @@ class LectureServiceTest {
         LectureApplicant expected = new LectureApplicant(lectureApplicantId, lectureOption, userId);
 
         //when
-        when(lectureOptionRepository.findById(lectureOptionId)).thenReturn(Optional.of(lectureOption));
+        when(lectureOptionRepository.findByIdWithPessimisticLock(lectureOptionId)).thenReturn(Optional.of(lectureOption));
         when(lectureApplicantRepository.apply(new LectureApplicant(lectureOption, userId))).thenReturn(expected);
 
         //then

--- a/src/test/java/io/hhplus/architecture/lecture/application/LectureServiceTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/application/LectureServiceTest.java
@@ -1,7 +1,124 @@
 package io.hhplus.architecture.lecture.application;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.hhplus.architecture.lecture.domain.*;
+import io.hhplus.architecture.lecture.domain.repository.LectureApplicantRepository;
+import io.hhplus.architecture.lecture.domain.repository.LectureOptionRepository;
+import io.hhplus.architecture.lecture.domain.repository.LectureRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 class LectureServiceTest {
 
+    @InjectMocks
+    private LectureService lectureService;
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private LectureOptionRepository lectureOptionRepository;
+
+    @Mock
+    private LectureApplicantRepository lectureApplicantRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("특강 신청 성공")
+    void lecture_apply_success() {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+        LocalDate lectureDate = LocalDate.of(2024, 6, 29);
+        LocalTime startTime = LocalTime.of(13, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+        Long maxCapacity = 30L;
+        Long appliedCount = 0L;
+        Long userId = 1L;
+        Long lectureApplicantId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        LectureOption lectureOption = new LectureOption(
+                lectureOptionId, lecture, lectureDate, startTime, endTime, maxCapacity, appliedCount);
+        LectureApplicant expected = new LectureApplicant(lectureApplicantId, lectureOption, userId);
+
+        //when
+        when(lectureOptionRepository.findById(lectureOptionId)).thenReturn(Optional.of(lectureOption));
+        when(lectureApplicantRepository.apply(new LectureApplicant(lectureOption, userId))).thenReturn(expected);
+
+        //then
+        assertThat(lectureService.applyLecture(lectureOptionId, userId)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("특강 목록조회 성공")
+    void lecture_list_fetch_success() {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        List<LectureOption> expected = List.of(
+                new LectureOption(lectureOptionId, lecture, LocalDate.of(2024, 6, 29),
+                        LocalTime.of(13, 0), LocalTime.of(18, 0), 30L, 0L),
+                new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 30),
+                        LocalTime.of(12, 0), LocalTime.of(13, 0), 40L, 0L),
+                new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 7, 1),
+                        LocalTime.of(14, 0), LocalTime.of(16, 0), 50L, 0L)
+        );
+
+        //when
+        when(lectureOptionRepository.findAll()).thenReturn(expected);
+
+        //then
+        assertThat(lectureService.getLectures()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("신청완료 특강 목록조회 성공")
+    void applied_lecture_list_fetch_success() {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+        Long lectureApplicantId = 1L;
+        Long userId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        LectureOption lectureOption = new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 29),
+                LocalTime.of(13, 0), LocalTime.of(18, 0), 30L, 0L);
+        LectureOption lectureOption2 = new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 30),
+                LocalTime.of(12, 0), LocalTime.of(13, 0), 40L, 0L);
+
+        List<LectureApplicant> expected = List.of(
+                new LectureApplicant(lectureApplicantId++, lectureOption, userId),
+                new LectureApplicant(lectureApplicantId++, lectureOption2, userId)
+        );
+
+        //when
+        when(lectureApplicantRepository.findAllByUserId(userId)).thenReturn(expected);
+
+        //then
+        assertThat(lectureService.getAppliedLecturesByUser(userId)).isEqualTo(expected);
+    }
 }

--- a/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
@@ -1,7 +1,141 @@
 package io.hhplus.architecture.lecture.presentation;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.architecture.lecture.application.LectureService;
+import io.hhplus.architecture.lecture.domain.Lecture;
+import io.hhplus.architecture.lecture.domain.LectureApplicant;
+import io.hhplus.architecture.lecture.domain.LectureOption;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// TODO: andExpect 부분에 추가 검증을 할 것인가..?
+
+/**
+ * MockMvc 사용하여 엔드포인트 요청 테스트 및 정상 응답에 대한 검증
+ */
+@WebMvcTest(LectureController.class)
 class LectureControllerTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    LectureService lectureService;
+
+    @Test
+    @DisplayName("특강 신청 성공")
+    void lecture_apply_success() throws Exception {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+        LocalDate lectureDate = LocalDate.of(2024, 6, 29);
+        LocalTime startTime = LocalTime.of(13, 0);
+        LocalTime endTime = LocalTime.of(18, 0);
+        Long maxCapacity = 30L;
+        Long appliedCount = 0L;
+        Long userId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        LectureOption lectureOption = new LectureOption(
+                lectureOptionId, lecture, lectureDate, startTime, endTime, maxCapacity, appliedCount);
+
+        //when
+        when(lectureService.applyLecture(anyLong(), anyLong())).thenReturn(new LectureApplicant(lectureOption, userId));
+
+        //then
+        LectureApplyRequestDto requestDto =
+                LectureApplyRequestDto.builder()
+                                      .lectureOptionId(lectureOptionId)
+                                      .userId(userId)
+                                      .build();
+
+        mockMvc.perform(post("/lectures/apply")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsString(requestDto)))
+               .andExpect(status().isOk());
+
+        verify(lectureService).applyLecture(lectureOptionId, userId);
+    }
+
+    @Test
+    @DisplayName("특강 목록조회 성공")
+    void lecture_list_fetch_success() throws Exception {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        List<LectureOption> expected = List.of(
+                new LectureOption(lectureOptionId, lecture, LocalDate.of(2024, 6, 29),
+                        LocalTime.of(13, 0), LocalTime.of(18, 0), 30L, 0L),
+                new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 30),
+                        LocalTime.of(12, 0), LocalTime.of(13, 0), 40L, 0L),
+                new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 7, 1),
+                        LocalTime.of(14, 0), LocalTime.of(16, 0), 50L, 0L)
+        );
+
+        //when
+        when(lectureService.getLectures()).thenReturn(expected);
+
+        //then
+        mockMvc.perform(get("/lectures"))
+               .andExpect(status().isOk());
+
+        verify(lectureService).getLectures();
+    }
+
+    @Test
+    @DisplayName("신청완료 특강 목록조회 성공")
+    void applied_lecture_list_fetch_success() throws Exception {
+        //given
+        Long lectureId = 1L;
+        String title = "항해플러스 특강";
+        String speaker = "OO 연사님";
+        Long lectureOptionId = 1L;
+        Long lectureApplicantId = 1L;
+        Long userId = 1L;
+
+        Lecture lecture = new Lecture(lectureId, title, speaker);
+        LectureOption lectureOption = new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 29),
+                LocalTime.of(13, 0), LocalTime.of(18, 0), 30L, 0L);
+        LectureOption lectureOption2 = new LectureOption(lectureOptionId++, lecture, LocalDate.of(2024, 6, 30),
+                LocalTime.of(12, 0), LocalTime.of(13, 0), 40L, 0L);
+
+        List<LectureApplicant> expected = List.of(
+                new LectureApplicant(lectureApplicantId++, lectureOption, userId),
+                new LectureApplicant(lectureApplicantId++, lectureOption2, userId)
+        );
+
+        //when
+        when(lectureService.getAppliedLecturesByUser(anyLong())).thenReturn(expected);
+
+        //then
+        mockMvc.perform(get("/lectures/application/{userId}", userId))
+               .andExpect(status().isOk());
+
+        verify(lectureService).getAppliedLecturesByUser(userId);
+    }
 }

--- a/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
@@ -1,6 +1,7 @@
 package io.hhplus.architecture.lecture.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.architecture.config.TestConfig;
 import io.hhplus.architecture.lecture.application.LectureService;
 import io.hhplus.architecture.lecture.domain.Lecture;
 import io.hhplus.architecture.lecture.domain.LectureApplicant;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * MockMvc 사용하여 엔드포인트 요청 테스트 및 정상 응답에 대한 검증
  */
+@Import(TestConfig.class)
 @WebMvcTest(LectureController.class)
 class LectureControllerTest {
 

--- a/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/architecture/lecture/presentation/LectureControllerTest.java
@@ -24,8 +24,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-// TODO: andExpect 부분에 추가 검증을 할 것인가..?
-
 /**
  * MockMvc 사용하여 엔드포인트 요청 테스트 및 정상 응답에 대한 검증
  */


### PR DESCRIPTION
### 변경사항
- ERD
   - 사용자 테이블은 별도 구성하지 않고, 신청 내역 테이블을 구성하는 컬럼으로만 추가함
<img width="633" alt="스크린샷 2024-06-27 오후 4 06 17" src="https://github.com/linglong67/hhplus-architecture/assets/88479739/6235a895-bf1a-4673-8124-f695a33aa842">

- API 구현
   - 특강 신청 API 구현
       - 예외 처리한 경우
          -  기존에 신청한 특강
          -  존재하지 않는 특강 옵션
          -  정원이 꽉찬 상태
          - 신청할 수 없는 날짜
   - 특강 신청 여부 조회 API 구현
      - 사용자 ID를 기준으로 조회하여 신청 내역 테이블에서 List 반환
   - 특강 목록 조회 API 구현
      -  전체 특강 목록 반환
- 아키텍처 구성 (크게 4개 계층으로 나눔)
   - presentation
   - application
   - domain
   - infrastructure
   
### 리뷰 포인트
- 이번 주차 과제의 요구사항을 만족하기 위해 ERD가 적절한지 궁금합니다
- 아키텍처 구성에 어떤 점을 보완하면 좋을지 궁금합니다